### PR TITLE
Refactor line processing and rendering with performance optimizations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
     push:
         branches:
-            - development
+            - merge
             - main
 
 jobs:

--- a/composer.lock
+++ b/composer.lock
@@ -593,11 +593,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.54",
+            "version": "2.1.55",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
-                "reference": "8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9eaac3826ed5e9b8427350a43cac825eeca3f566",
+                "reference": "9eaac3826ed5e9b8427350a43cac825eeca3f566",
                 "shasum": ""
             },
             "require": {
@@ -642,20 +642,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-29T13:31:09+00:00"
+            "time": "2026-05-18T11:57:34+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "14.1.7",
+            "version": "14.1.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "da6e6b64940901650abcea62430c8c24926b7a71"
+                "reference": "655533a65696bbc4231cd8027af150dadc40ec88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/da6e6b64940901650abcea62430c8c24926b7a71",
-                "reference": "da6e6b64940901650abcea62430c8c24926b7a71",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/655533a65696bbc4231cd8027af150dadc40ec88",
+                "reference": "655533a65696bbc4231cd8027af150dadc40ec88",
                 "shasum": ""
             },
             "require": {
@@ -712,7 +712,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.1.7"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.1.9"
             },
             "funding": [
                 {
@@ -732,7 +732,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-04T15:51:53+00:00"
+            "time": "2026-05-16T05:16:14+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1029,16 +1029,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "13.1.8",
+            "version": "13.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f49a2b5e51ffb33421745368cc099cf66830d71b"
+                "reference": "38959098d3c10660a189afaa35a94290c1de67bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f49a2b5e51ffb33421745368cc099cf66830d71b",
-                "reference": "f49a2b5e51ffb33421745368cc099cf66830d71b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/38959098d3c10660a189afaa35a94290c1de67bb",
+                "reference": "38959098d3c10660a189afaa35a94290c1de67bb",
                 "shasum": ""
             },
             "require": {
@@ -1052,14 +1052,14 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.4.1",
-                "phpunit/php-code-coverage": "^14.1.6",
+                "phpunit/php-code-coverage": "^14.1.8",
                 "phpunit/php-file-iterator": "^7.0.0",
                 "phpunit/php-invoker": "^7.0.0",
                 "phpunit/php-text-template": "^6.0.0",
                 "phpunit/php-timer": "^9.0.0",
                 "sebastian/cli-parser": "^5.0.0",
-                "sebastian/comparator": "^8.1.2",
-                "sebastian/diff": "^8.1.0",
+                "sebastian/comparator": "^8.1.3",
+                "sebastian/diff": "^8.3.0",
                 "sebastian/environment": "^9.3.0",
                 "sebastian/exporter": "^8.0.2",
                 "sebastian/git-state": "^1.0",
@@ -1108,7 +1108,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.8"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.10"
             },
             "funding": [
                 {
@@ -1116,20 +1116,20 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-05-01T04:22:45+00:00"
+            "time": "2026-05-15T08:03:56+00:00"
         },
         {
             "name": "rector/rector",
-            "version": "2.4.2",
+            "version": "2.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "e645b6463c6a88ea5b44b17d3387d35a912c7946"
+                "reference": "891824c6c59f02a56a5dd58ea8edc44e6c0ece29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/e645b6463c6a88ea5b44b17d3387d35a912c7946",
-                "reference": "e645b6463c6a88ea5b44b17d3387d35a912c7946",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/891824c6c59f02a56a5dd58ea8edc44e6c0ece29",
+                "reference": "891824c6c59f02a56a5dd58ea8edc44e6c0ece29",
                 "shasum": ""
             },
             "require": {
@@ -1168,7 +1168,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.2"
+                "source": "https://github.com/rectorphp/rector/tree/2.4.3"
             },
             "funding": [
                 {
@@ -1176,7 +1176,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-16T13:07:34+00:00"
+            "time": "2026-05-12T11:17:24+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1249,27 +1249,27 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "8.1.2",
+            "version": "8.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "b3d09f4360ad97dcad8f82d1c047ad16ff38b7e1"
+                "reference": "ddacb462216a4f6d97e84bf08165b9074ddbafeb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/b3d09f4360ad97dcad8f82d1c047ad16ff38b7e1",
-                "reference": "b3d09f4360ad97dcad8f82d1c047ad16ff38b7e1",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ddacb462216a4f6d97e84bf08165b9074ddbafeb",
+                "reference": "ddacb462216a4f6d97e84bf08165b9074ddbafeb",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
                 "php": ">=8.4",
-                "sebastian/diff": "^8.1",
-                "sebastian/exporter": "^8.0"
+                "sebastian/diff": "^8.3",
+                "sebastian/exporter": "^8.0.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.0"
+                "phpunit/phpunit": "^13.1.10"
             },
             "suggest": {
                 "ext-bcmath": "For comparing BcMath\\Number objects"
@@ -1277,7 +1277,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.1-dev"
+                    "dev-main": "8.2-dev"
                 }
             },
             "autoload": {
@@ -1317,7 +1317,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/8.1.2"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/8.2.0"
             },
             "funding": [
                 {
@@ -1337,7 +1337,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-14T08:24:42+00:00"
+            "time": "2026-05-20T11:55:37+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -1411,16 +1411,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "8.1.0",
+            "version": "8.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "9c957d730257f49c873f3761674559bd90098a7d"
+                "reference": "b36d33b6e796513de7cb7df053afb3f55eefcd47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/9c957d730257f49c873f3761674559bd90098a7d",
-                "reference": "9c957d730257f49c873f3761674559bd90098a7d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b36d33b6e796513de7cb7df053afb3f55eefcd47",
+                "reference": "b36d33b6e796513de7cb7df053afb3f55eefcd47",
                 "shasum": ""
             },
             "require": {
@@ -1433,7 +1433,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.1-dev"
+                    "dev-main": "8.3-dev"
                 }
             },
             "autoload": {
@@ -1466,7 +1466,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/8.1.0"
+                "source": "https://github.com/sebastianbergmann/diff/tree/8.3.0"
             },
             "funding": [
                 {
@@ -1486,7 +1486,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-05T12:02:33+00:00"
+            "time": "2026-05-15T04:58:09+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1566,16 +1566,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "8.0.2",
+            "version": "8.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "9cee180ebe62259e3ed48df2212d1fc8cfd971bb"
+                "reference": "9b54f1afabb977a097ef353600d41a372ccde617"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/9cee180ebe62259e3ed48df2212d1fc8cfd971bb",
-                "reference": "9cee180ebe62259e3ed48df2212d1fc8cfd971bb",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/9b54f1afabb977a097ef353600d41a372ccde617",
+                "reference": "9b54f1afabb977a097ef353600d41a372ccde617",
                 "shasum": ""
             },
             "require": {
@@ -1584,7 +1584,7 @@
                 "sebastian/recursion-context": "^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.0"
+                "phpunit/phpunit": "^13.1.10"
             },
             "type": "library",
             "extra": {
@@ -1632,7 +1632,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/8.0.2"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/8.0.3"
             },
             "funding": [
                 {
@@ -1652,7 +1652,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-15T12:38:05+00:00"
+            "time": "2026-05-20T04:38:47+00:00"
         },
         {
             "name": "sebastian/git-state",
@@ -1799,24 +1799,24 @@
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "4f21bb7768e1c997722ccc7efb1d6b5c11bfd471"
+                "reference": "d2cff273a90c79b0eb590baa682d4b5c318bdbb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/4f21bb7768e1c997722ccc7efb1d6b5c11bfd471",
-                "reference": "4f21bb7768e1c997722ccc7efb1d6b5c11bfd471",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d2cff273a90c79b0eb590baa682d4b5c318bdbb7",
+                "reference": "d2cff273a90c79b0eb590baa682d4b5c318bdbb7",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^5.0",
+                "nikic/php-parser": "^5.7.0",
                 "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.0"
+                "phpunit/phpunit": "^13.1.10"
             },
             "type": "library",
             "extra": {
@@ -1845,7 +1845,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/5.0.0"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/5.0.1"
             },
             "funding": [
                 {
@@ -1865,7 +1865,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-06T04:45:54+00:00"
+            "time": "2026-05-19T16:23:37+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -2083,23 +2083,23 @@
         },
         {
             "name": "sebastian/type",
-            "version": "7.0.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "42412224607bd3931241bbd17f38e0f972f5a916"
+                "reference": "fee0309275847fefd7636167085e379c1dbf6990"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/42412224607bd3931241bbd17f38e0f972f5a916",
-                "reference": "42412224607bd3931241bbd17f38e0f972f5a916",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fee0309275847fefd7636167085e379c1dbf6990",
+                "reference": "fee0309275847fefd7636167085e379c1dbf6990",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.0"
+                "phpunit/phpunit": "^13.1.10"
             },
             "type": "library",
             "extra": {
@@ -2128,7 +2128,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
                 "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/7.0.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/7.0.1"
             },
             "funding": [
                 {
@@ -2148,7 +2148,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-06T04:52:09+00:00"
+            "time": "2026-05-20T06:49:11+00:00"
         },
         {
             "name": "sebastian/version",

--- a/src/DataProcessing.php
+++ b/src/DataProcessing.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Brace;
 
 trait DataProcessing

--- a/src/DataProcessing.php
+++ b/src/DataProcessing.php
@@ -104,7 +104,10 @@ trait DataProcessing
      */
     private static function checkForCallable(string $input): array
     {
-        if (preg_match("/^([\\\A-Za-z_]+::[A-Za-z_]+)$|^([\\\A-Za-z_]+::[A-Za-z_]+)\((.*?)\)$/", $input, $match)) {
+        if (
+            str_contains($input, '::')
+            && preg_match("/^([\\\A-Za-z_]+::[A-Za-z_]+)$|^([\\\A-Za-z_]+::[A-Za-z_]+)\((.*?)\)$/", $input, $match)
+        ) {
             if (count($match) === 4) {
                 return [
                     'callable' => $match[2],

--- a/src/DataProcessing.php
+++ b/src/DataProcessing.php
@@ -90,7 +90,7 @@ trait DataProcessing
      */
     private static function checkForCount(string $input): string
     {
-        if (preg_match("/^COUNT\((.*?)\)/", $input, $match)) {
+        if (str_contains($input, 'COUNT(') && preg_match("/^COUNT\((.*?)\)/", $input, $match)) {
             return $match[1];
         }
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -814,7 +814,7 @@ final class Parser
                 // Check if variable is an array and empty, replace with empty string
                 $replace_variable = is_array($replace_variable) && empty($replace_variable)
                     ? ''
-                    : (string) $replace_variable;
+                    : (is_array($replace_variable) ? $replace_variable : (string) $replace_variable);
 
                 // Replace variable in template string
                 $template_string = str_replace($replace_string, $replace_variable, $template_string);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -512,12 +512,7 @@ final class Parser
     private function processBlock(string $block_string, array $conditions, array $dataset): string
     {
         /** Remove phantom line break */
-        $block_string = explode("\n", $block_string);
-        if (strlen($block_string[count($block_string) - 1]) === 0) {
-            array_pop($block_string);
-        }
-
-        $block_string = implode("\n", $block_string);
+        $block_string = rtrim($block_string, "\n");
 
         $process_content = '';
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -602,6 +602,9 @@ final class Parser
                     break;
                 }
             }
+
+            /** Unset the parser instance to free up memory */
+            unset($process_each_block);
         }
 
         return $return_string;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -485,12 +485,13 @@ final class Parser
             }
         }
 
-        /** Output current line */
-        if ($render) {
-            echo $this_line;
-        } else {
+        // Check if line should not be rendered
+        if (!$render) {
             $this->export_string .= $this_line;
+            return;
         }
+
+        echo $this_line;
     }
 
     /**

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  *   Brace
  *   Copyright (C) 2026 Alex Oliver
@@ -818,7 +820,9 @@ final class Parser
                 }
 
                 // Check if variable is an array and empty, replace with empty string
-                $replace_variable = is_array($replace_variable) && empty($replace_variable) ? '' : $replace_variable;
+                $replace_variable = is_array($replace_variable) && empty($replace_variable)
+                    ? ''
+                    : (string) $replace_variable;
 
                 // Replace variable in template string
                 $template_string = str_replace($replace_string, $replace_variable, $template_string);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -276,6 +276,23 @@ final class Parser
         }
     }
 
+    // Check if line should be processed
+    private function shouldProcessLine(string $this_line): bool
+    {
+        // Check if line is empty
+        if (trim($this_line) === '') {
+            return false;
+        }
+
+        // Check if line is part of a comment block or is part of a block
+        if ($this->is_comment_block || $this->is_block) {
+            return true;
+        }
+
+        // Check contains template functionality
+        return (bool) preg_match('/{{|}}|<!--|-->|\[|]|([a-zA-Z0-9_-]+)\((.*?)\)/s', $this_line);
+    }
+
     /**
      * Process single line
      *
@@ -289,168 +306,180 @@ final class Parser
         /** Increment current line counter */
         $this->current_line += 1;
 
-        /** Check for start of JS tag */
-        if (!$this->is_js_script && preg_match('/<script(.*?)>/', $this_line)) {
-            $this->is_js_script = true;
-        }
+        // Check if line should be processed
+        if ($this->shouldProcessLine($this_line)) {
+            /** Check for start of inline JS tag */
+            if (!$this->is_js_script && preg_match('/<script(.*?)>/', $this_line)) {
+                $this->is_js_script = true;
+            }
 
-        // Still process variables, in-line conditions and in-line iterators for items in script tag
-        $this_line = $this->is_js_script ? $this->processVariables((string) $this_line, $dataset) : $this_line;
+            // Still process variables, in-line conditions and in-line iterators for items in script tag
+            $this_line = $this->is_js_script ? $this->processVariables((string) $this_line, $dataset) : $this_line;
 
-        // Check for end of JS script tag
-        if ($this->is_js_script && preg_match("/<\/script>/", $this_line)) {
-            $this->is_js_script = false;
-        }
+            // Check for end of inline JS script tag
+            if ($this->is_js_script && preg_match("/<\/script>/", $this_line)) {
+                $this->is_js_script = false;
+            }
 
-        if (!$this->is_js_script) {
-            /** Remove comment blocks */
-            if ($this->remove_comment_blocks) {
-                /** Is inline comment */
-                if (preg_match('/<!--(.*?)-->/', $this_line)) {
-                    $this_line = preg_replace('/<!--(.*?)-->/', '', $this_line);
-                }
-
-                /** Is comment block */
-                if (
-                    preg_match_all('/<!--|-->/i', (string) $this_line, $matches, PREG_SET_ORDER)
-                    || $this->is_comment_block
-                ) {
-                    switch (isset($matches[0]) ? $matches[0][0] : '') {
-                        case '<!--':
-                            $this->is_comment_block = true;
-                            break;
-                        case '-->':
-                            $this->is_comment_block = false;
-                            break;
+            if (!$this->is_js_script) {
+                /** Remove comment blocks */
+                if ($this->remove_comment_blocks) {
+                    /** Is inline comment */
+                    if (preg_match('/<!--(.*?)-->/', $this_line)) {
+                        $this_line = preg_replace('/<!--(.*?)-->/', '', $this_line);
                     }
 
-                    /** Is inline comment */
-                    $this->is_comment_block =
-                        $this->is_comment_block && isset($matches[1][0]) && trim($matches[1][0]) === '-->'
-                            ? false
-                            : $this->is_comment_block;
+                    /** Is comment block */
+                    if (
+                        preg_match_all('/<!--|-->/i', (string) $this_line, $matches, PREG_SET_ORDER)
+                        || $this->is_comment_block
+                    ) {
+                        switch (isset($matches[0]) ? $matches[0][0] : '') {
+                            case '<!--':
+                                $this->is_comment_block = true;
+                                break;
+                            case '-->':
+                                $this->is_comment_block = false;
+                                break;
+                        }
+
+                        /** Is inline comment */
+                        $this->is_comment_block =
+                            $this->is_comment_block && isset($matches[1][0]) && trim($matches[1][0]) === '-->'
+                                ? false
+                                : $this->is_comment_block;
+
+                        /** Blank line */
+                        $this_line = '';
+                    }
+                }
+
+                /** Remove preceding and following whitespace */
+                $spacing_match = "/{{\s*(.*?)\s*}}/";
+                if (is_string($this_line) && preg_match_all($spacing_match, $this_line, $matches, PREG_SET_ORDER)) {
+                    foreach ($matches as $match) {
+                        $this_line = str_replace($match[0], '{{' . $match[1] . '}}', (string) $this_line);
+                    }
+                }
+
+                /** Process if condition or each block */
+                if (
+                    !$this->is_block
+                    && preg_match_all(
+                        '/{{if (.*?)}}|{{each (.*?)}}|{{loop (.*?)}}/i',
+                        (string) $this_line,
+                        $matches,
+                        PREG_SET_ORDER,
+                    )
+                ) {
+                    // Check if block is an inline block with {{end}}
+                    if (strpos((string) $this_line, '{{end}}') !== false) {
+                        throw new SyntaxError(
+                            message: 'Blocks must not be inline',
+                            line: $this->current_line,
+                            file: $this->current_template,
+                        );
+                    }
+
+                    /** Set block variables */
+                    $this->block_condition = $matches[0];
+
+                    /** Set condition type */
+                    $condition_type = $this->block_condition[0];
+
+                    preg_match('/{{(.*?) /', $condition_type, $match_types);
+                    $block_type = '';
+
+                    if (isset($match_types[1])) {
+                        switch ($match_types[1]) {
+                            case 'if':
+                            case 'each':
+                            case 'loop':
+                                $block_type = $match_types[1];
+                                break;
+                        }
+                    }
+
+                    $this->block_condition[] = $block_type;
+                    $this->block_spaces = (int) strpos((string) $this_line, '{{' . $block_type);
+                    $this->is_block = true;
+
+                    /** Blank line */
+                    $this_line = '';
+                } elseif (
+                    $this->is_block
+                    && rtrim((string) $this_line) === str_pad(
+                        '{{end}}',
+                        strlen('{{end}}') + $this->block_spaces,
+                        ' ',
+                        STR_PAD_LEFT,
+                    )
+                ) {
+                    /** Process block */
+                    $this_line = $this->processBlock($this->block_content, $this->block_condition, $dataset);
+
+                    /** Clear block variables */
+                    $this->block_condition = [];
+                    $this->block_content = '';
+                    $this->is_block = false;
+                    $this->block_spaces = 0;
+                } elseif ($this->is_block) {
+                    /** Add current line to block content */
+                    $this->block_content .= $this_line;
 
                     /** Blank line */
                     $this_line = '';
                 }
-            }
 
-            /** Remove preceding and following whitespace */
-            $spacing_match = "/{{\s*(.*?)\s*}}/";
-            if (is_string($this_line) && preg_match_all($spacing_match, $this_line, $matches, PREG_SET_ORDER)) {
-                foreach ($matches as $match) {
-                    $this_line = str_replace($match[0], '{{' . $match[1] . '}}', (string) $this_line);
-                }
-            }
-
-            /** Process if condition or each block */
-            if (
-                !$this->is_block
-                && preg_match_all(
-                    '/{{if (.*?)}}|{{each (.*?)}}|{{loop (.*?)}}/i',
+                /** process included templates */
+                if (preg_match_all(
+                    "/(\[@include )(.*?)(])/",
                     (string) $this_line,
-                    $matches,
+                    $include_templates,
                     PREG_SET_ORDER,
-                )
-            ) {
-                // Check if block is an inline block with {{end}}
-                if (strpos((string) $this_line, '{{end}}') !== false) {
-                    throw new SyntaxError(
-                        message: 'Blocks must not be inline',
-                        line: $this->current_line,
-                        file: $this->current_template,
-                    );
+                )) {
+                    foreach ($include_templates as $to_include) {
+                        foreach (explode(' ', trim($to_include[2])) as $template) {
+                            $template = $this->processVariables($template, $dataset);
+                            $this->parse($template, $dataset, $render);
+                        }
+                    }
+
+                    /** Blank line */
+                    $this_line = '';
                 }
 
-                /** Set block variables */
-                $this->block_condition = $matches[0];
+                /** Process variables, in-line conditions and in-line iterators */
+                $this_line = $this->processVariables((string) $this_line, $dataset);
 
-                /** Set condition type */
-                $condition_type = $this->block_condition[0];
-
-                preg_match('/{{(.*?) /', $condition_type, $match_types);
-                $block_type = '';
-
-                if (isset($match_types[1])) {
-                    switch ($match_types[1]) {
-                        case 'if':
-                        case 'each':
-                        case 'loop':
-                            $block_type = $match_types[1];
-                            break;
+                /** Is shortcode */
+                if (preg_match_all("/\[(.*?)\]/", $this_line, $matches, PREG_SET_ORDER)) {
+                    foreach ($matches as $theShortcode) {
+                        /** @disregard */
+                        $this_line = function_exists('do_shortcode')
+                            ? str_replace(
+                                $theShortcode[0],
+                                do_shortcode($this->processVariables($theShortcode[0], $dataset)),
+                                $this_line,
+                            )
+                            : str_replace(
+                                $theShortcode[0],
+                                $this->callShortcode($theShortcode[0], $dataset),
+                                $this_line,
+                            );
                     }
                 }
 
-                $this->block_condition[] = $block_type;
-                $this->block_spaces = (int) strpos((string) $this_line, '{{' . $block_type);
-                $this->is_block = true;
-
-                /** Blank line */
-                $this_line = '';
-            } elseif (
-                $this->is_block
-                && rtrim((string) $this_line) === str_pad(
-                    '{{end}}',
-                    strlen('{{end}}') + $this->block_spaces,
-                    ' ',
-                    STR_PAD_LEFT,
-                )
-            ) {
-                /** Process block */
-                $this_line = $this->processBlock($this->block_content, $this->block_condition, $dataset);
-
-                /** Clear block variables */
-                $this->block_condition = [];
-                $this->block_content = '';
-                $this->is_block = false;
-                $this->block_spaces = 0;
-            } elseif ($this->is_block) {
-                /** Add current line to block content */
-                $this->block_content .= $this_line;
-
-                /** Blank line */
-                $this_line = '';
-            }
-
-            /** process included templates */
-            if (preg_match_all("/(\[@include )(.*?)(])/", (string) $this_line, $include_templates, PREG_SET_ORDER)) {
-                foreach ($include_templates as $to_include) {
-                    foreach (explode(' ', trim($to_include[2])) as $template) {
-                        $template = $this->processVariables($template, $dataset);
-                        $this->parse($template, $dataset, $render);
-                    }
-                }
-
-                /** Blank line */
-                $this_line = '';
-            }
-
-            /** Process variables, in-line conditions and in-line iterators */
-            $this_line = $this->processVariables((string) $this_line, $dataset);
-
-            /** Is shortcode */
-            if (preg_match_all("/\[(.*?)\]/", $this_line, $matches, PREG_SET_ORDER)) {
-                foreach ($matches as $theShortcode) {
-                    /** @disregard */
-                    $this_line = function_exists('do_shortcode')
-                        ? str_replace(
-                            $theShortcode[0],
-                            do_shortcode($this->processVariables($theShortcode[0], $dataset)),
-                            $this_line,
-                        )
-                        : str_replace($theShortcode[0], $this->callShortcode($theShortcode[0], $dataset), $this_line);
-                }
-            }
-
-            /** Is Callable */
-            if (preg_match_all("/([a-zA-Z0-9_-]+)\((.*?)\)/", $this_line, $matches, PREG_SET_ORDER)) {
-                foreach ($matches as $callableMethod) {
-                    if (isset($this->callable_methods[$callableMethod[1]])) {
-                        $this_line = str_replace(
-                            $callableMethod[0],
-                            $this->callables(method: $callableMethod[1], content: $callableMethod[2]),
-                            $this_line,
-                        );
+                /** Is Callable */
+                if (preg_match_all("/([a-zA-Z0-9_-]+)\((.*?)\)/", $this_line, $matches, PREG_SET_ORDER)) {
+                    foreach ($matches as $callableMethod) {
+                        if (isset($this->callable_methods[$callableMethod[1]])) {
+                            $this_line = str_replace(
+                                $callableMethod[0],
+                                $this->callables(method: $callableMethod[1], content: $callableMethod[2]),
+                                $this_line,
+                            );
+                        }
                     }
                 }
             }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -588,29 +588,18 @@ final class Parser
             /** new core parser class instance */
             $process_each_block = $this->newParserInstance();
 
-            if ($from < $to) {
-                for ($i = $from; $i <= $to; $i += 1) {
-                    $process_each_block->parseInputString(
-                        $block_content,
-                        [
-                            '_KEY' => $i,
-                        ],
-                        false,
-                    );
-                    $return_string .= $process_each_block->return();
-                    $process_each_block->export_string = '';
-                }
-            } else {
-                for ($i = $from; $i >= $to; $i -= 1) {
-                    $process_each_block->parseInputString(
-                        $block_content,
-                        [
-                            '_KEY' => $i,
-                        ],
-                        false,
-                    );
-                    $return_string .= $process_each_block->return();
-                    $process_each_block->export_string = '';
+            /** Determine the step size based on the loop direction */
+            $step = $from < $to ? 1 : -1;
+
+            /** Loop through the range of values */
+            for ($index = $from;; $index += $step) {
+                $process_each_block->parseInputString($block_content, ['_KEY' => $index], false);
+                $return_string .= $process_each_block->return();
+                $process_each_block->clear();
+
+                // Check if we've reached the end of the loop
+                if ($index === $to) {
+                    break;
                 }
             }
         }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -313,182 +313,173 @@ final class Parser
         /** Increment current line counter */
         $this->current_line += 1;
 
+        /** Check for start of inline JS tag */
+        if (!$this->is_js_script && preg_match('/<script(.*?)>/', $this_line)) {
+            $this->is_js_script = true;
+        }
+
+        // Still process variables, in-line conditions and in-line iterators for items in script tag
+        if ($this->is_js_script) {
+            $this_line = $this->processVariables((string) $this_line, $dataset);
+        }
+
+        // Check for end of inline JS script tag
+        if ($this->is_js_script && preg_match("/<\/script>/", $this_line)) {
+            $this->is_js_script = false;
+        }
+
         // Check if line should be processed
-        if ($this->shouldProcessLine($this_line)) {
-            /** Check for start of inline JS tag */
-            if (!$this->is_js_script && preg_match('/<script(.*?)>/', $this_line)) {
-                $this->is_js_script = true;
-            }
-
-            // Still process variables, in-line conditions and in-line iterators for items in script tag
-            $this_line = $this->is_js_script ? $this->processVariables((string) $this_line, $dataset) : $this_line;
-
-            // Check for end of inline JS script tag
-            if ($this->is_js_script && preg_match("/<\/script>/", $this_line)) {
-                $this->is_js_script = false;
-            }
-
-            if (!$this->is_js_script) {
-                /** Remove comment blocks */
-                if ($this->remove_comment_blocks) {
-                    /** Is inline comment */
-                    if (preg_match('/<!--(.*?)-->/', $this_line)) {
-                        $this_line = preg_replace('/<!--(.*?)-->/', '', $this_line);
-                    }
-
-                    /** Is comment block */
-                    if (
-                        preg_match_all('/<!--|-->/i', (string) $this_line, $matches, PREG_SET_ORDER)
-                        || $this->is_comment_block
-                    ) {
-                        switch (isset($matches[0]) ? $matches[0][0] : '') {
-                            case '<!--':
-                                $this->is_comment_block = true;
-                                break;
-                            case '-->':
-                                $this->is_comment_block = false;
-                                break;
-                        }
-
-                        /** Is inline comment */
-                        $this->is_comment_block =
-                            $this->is_comment_block && isset($matches[1][0]) && trim($matches[1][0]) === '-->'
-                                ? false
-                                : $this->is_comment_block;
-
-                        /** Blank line */
-                        $this_line = '';
-                    }
+        if (!$this->is_js_script && $this->shouldProcessLine($this_line)) {
+            /** Remove comment blocks */
+            if ($this->remove_comment_blocks) {
+                /** Is inline comment */
+                if (preg_match('/<!--(.*?)-->/', $this_line)) {
+                    $this_line = preg_replace('/<!--(.*?)-->/', '', $this_line);
                 }
 
-                /** Remove preceding and following whitespace */
-                $spacing_match = "/{{\s*(.*?)\s*}}/";
-                if (is_string($this_line) && preg_match_all($spacing_match, $this_line, $matches, PREG_SET_ORDER)) {
-                    foreach ($matches as $match) {
-                        $this_line = str_replace($match[0], '{{' . $match[1] . '}}', (string) $this_line);
-                    }
-                }
-
-                /** Process if condition or each block */
+                /** Is comment block */
                 if (
-                    !$this->is_block
-                    && preg_match_all(
-                        '/{{if (.*?)}}|{{each (.*?)}}|{{loop (.*?)}}/i',
-                        (string) $this_line,
-                        $matches,
-                        PREG_SET_ORDER,
-                    )
+                    preg_match_all('/<!--|-->/i', (string) $this_line, $matches, PREG_SET_ORDER)
+                    || $this->is_comment_block
                 ) {
-                    // Check if block is an inline block with {{end}}
-                    if (strpos((string) $this_line, '{{end}}') !== false) {
-                        throw new SyntaxError(
-                            message: 'Blocks must not be inline',
-                            line: $this->current_line,
-                            file: $this->current_template,
-                        );
+                    switch (isset($matches[0]) ? $matches[0][0] : '') {
+                        case '<!--':
+                            $this->is_comment_block = true;
+                            break;
+                        case '-->':
+                            $this->is_comment_block = false;
+                            break;
                     }
 
-                    /** Set block variables */
-                    $this->block_condition = $matches[0];
-
-                    /** Set condition type */
-                    $condition_type = $this->block_condition[0];
-
-                    preg_match('/{{(.*?) /', $condition_type, $match_types);
-                    $block_type = '';
-
-                    if (isset($match_types[1])) {
-                        switch ($match_types[1]) {
-                            case 'if':
-                            case 'each':
-                            case 'loop':
-                                $block_type = $match_types[1];
-                                break;
-                        }
-                    }
-
-                    $this->block_condition[] = $block_type;
-                    $this->block_spaces = (int) strpos((string) $this_line, '{{' . $block_type);
-                    $this->is_block = true;
-
-                    /** Blank line */
-                    $this_line = '';
-                } elseif (
-                    $this->is_block
-                    && rtrim((string) $this_line) === str_pad(
-                        '{{end}}',
-                        strlen('{{end}}') + $this->block_spaces,
-                        ' ',
-                        STR_PAD_LEFT,
-                    )
-                ) {
-                    /** Process block */
-                    $this_line = $this->processBlock($this->block_content, $this->block_condition, $dataset);
-
-                    /** Clear block variables */
-                    $this->block_condition = [];
-                    $this->block_content = '';
-                    $this->is_block = false;
-                    $this->block_spaces = 0;
-                } elseif ($this->is_block) {
-                    /** Add current line to block content */
-                    $this->block_content .= $this_line;
+                    /** Is inline comment */
+                    $this->is_comment_block =
+                        $this->is_comment_block && isset($matches[1][0]) && trim($matches[1][0]) === '-->'
+                            ? false
+                            : $this->is_comment_block;
 
                     /** Blank line */
                     $this_line = '';
                 }
+            }
 
-                /** process included templates */
-                if (preg_match_all(
-                    "/(\[@include )(.*?)(])/",
+            /** Remove preceding and following whitespace */
+            $spacing_match = "/{{\s*(.*?)\s*}}/";
+            if (is_string($this_line) && preg_match_all($spacing_match, $this_line, $matches, PREG_SET_ORDER)) {
+                foreach ($matches as $match) {
+                    $this_line = str_replace($match[0], '{{' . $match[1] . '}}', (string) $this_line);
+                }
+            }
+
+            /** Process if condition or each block */
+            if (
+                !$this->is_block
+                && preg_match_all(
+                    '/{{if (.*?)}}|{{each (.*?)}}|{{loop (.*?)}}/i',
                     (string) $this_line,
-                    $include_templates,
+                    $matches,
                     PREG_SET_ORDER,
-                )) {
-                    foreach ($include_templates as $to_include) {
-                        foreach (explode(' ', trim($to_include[2])) as $template) {
-                            $template = $this->processVariables($template, $dataset);
-                            $this->parse($template, $dataset, $render);
-                        }
-                    }
-
-                    /** Blank line */
-                    $this_line = '';
+                )
+            ) {
+                // Check if block is an inline block with {{end}}
+                if (strpos((string) $this_line, '{{end}}') !== false) {
+                    throw new SyntaxError(
+                        message: 'Blocks must not be inline',
+                        line: $this->current_line,
+                        file: $this->current_template,
+                    );
                 }
 
-                /** Process variables, in-line conditions and in-line iterators */
-                $this_line = $this->processVariables((string) $this_line, $dataset);
+                /** Set block variables */
+                $this->block_condition = $matches[0];
 
-                /** Check if WP do_shortcode function exists */
-                $is_wp_shortcode = function_exists('do_shortcode');
+                /** Set condition type */
+                $condition_type = $this->block_condition[0];
 
-                /** Is shortcode */
-                if (preg_match_all("/\[(.*?)\]/", $this_line, $matches, PREG_SET_ORDER)) {
-                    foreach ($matches as $theShortcode) {
-                        $this_line = $is_wp_shortcode
-                            ? str_replace(
-                                $theShortcode[0],
-                                do_shortcode($this->processVariables($theShortcode[0], $dataset)),
-                                $this_line,
-                            )
-                            : str_replace(
-                                $theShortcode[0],
-                                $this->callShortcode($theShortcode[0], $dataset),
-                                $this_line,
-                            );
+                preg_match('/{{(.*?) /', $condition_type, $match_types);
+                $block_type = '';
+
+                if (isset($match_types[1])) {
+                    switch ($match_types[1]) {
+                        case 'if':
+                        case 'each':
+                        case 'loop':
+                            $block_type = $match_types[1];
+                            break;
                     }
                 }
 
-                /** Is Callable */
-                if (preg_match_all("/([a-zA-Z0-9_-]+)\((.*?)\)/", $this_line, $matches, PREG_SET_ORDER)) {
-                    foreach ($matches as $callableMethod) {
-                        if (isset($this->callable_methods[$callableMethod[1]])) {
-                            $this_line = str_replace(
-                                $callableMethod[0],
-                                $this->callables(method: $callableMethod[1], content: $callableMethod[2]),
-                                $this_line,
-                            );
-                        }
+                $this->block_condition[] = $block_type;
+                $this->block_spaces = (int) strpos((string) $this_line, '{{' . $block_type);
+                $this->is_block = true;
+
+                /** Blank line */
+                $this_line = '';
+            } elseif (
+                $this->is_block
+                && rtrim((string) $this_line) === str_pad(
+                    '{{end}}',
+                    strlen('{{end}}') + $this->block_spaces,
+                    ' ',
+                    STR_PAD_LEFT,
+                )
+            ) {
+                /** Process block */
+                $this_line = $this->processBlock($this->block_content, $this->block_condition, $dataset);
+
+                /** Clear block variables */
+                $this->block_condition = [];
+                $this->block_content = '';
+                $this->is_block = false;
+                $this->block_spaces = 0;
+            } elseif ($this->is_block) {
+                /** Add current line to block content */
+                $this->block_content .= $this_line;
+
+                /** Blank line */
+                $this_line = '';
+            }
+
+            /** process included templates */
+            if (preg_match_all("/(\[@include )(.*?)(])/", (string) $this_line, $include_templates, PREG_SET_ORDER)) {
+                foreach ($include_templates as $to_include) {
+                    foreach (explode(' ', trim($to_include[2])) as $template) {
+                        $template = $this->processVariables($template, $dataset);
+                        $this->parse($template, $dataset, $render);
+                    }
+                }
+
+                /** Blank line */
+                $this_line = '';
+            }
+
+            /** Process variables, in-line conditions and in-line iterators */
+            $this_line = $this->processVariables((string) $this_line, $dataset);
+
+            /** Check if WP do_shortcode function exists */
+            $is_wp_shortcode = function_exists('do_shortcode');
+
+            /** Is shortcode */
+            if (preg_match_all("/\[(.*?)\]/", $this_line, $matches, PREG_SET_ORDER)) {
+                foreach ($matches as $theShortcode) {
+                    $this_line = $is_wp_shortcode
+                        ? str_replace(
+                            $theShortcode[0],
+                            do_shortcode($this->processVariables($theShortcode[0], $dataset)),
+                            $this_line,
+                        )
+                        : str_replace($theShortcode[0], $this->callShortcode($theShortcode[0], $dataset), $this_line);
+                }
+            }
+
+            /** Is Callable */
+            if (preg_match_all("/([a-zA-Z0-9_-]+)\((.*?)\)/", $this_line, $matches, PREG_SET_ORDER)) {
+                foreach ($matches as $callableMethod) {
+                    if (isset($this->callable_methods[$callableMethod[1]])) {
+                        $this_line = str_replace(
+                            $callableMethod[0],
+                            $this->callables(method: $callableMethod[1], content: $callableMethod[2]),
+                            $this_line,
+                        );
                     }
                 }
             }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -795,11 +795,10 @@ final class Parser
                 $replace_string = $this_data_variable[0];
                 $processString = $this_data_variable[2];
 
-                $is_condition = preg_match_all("/ \? /", $processString);
-                $is_itterator = preg_match_all('/ as /', $processString);
-                $has_alternative_vars = explode(' || ', $processString);
+                $is_condition = str_contains($processString, ' ? ') ? preg_match_all("/ \? /", $processString) : false;
+                $is_itterator = str_contains($processString, ' as ') ? preg_match_all('/ as /', $processString) : false;
+                $has_alternative_vars = str_contains($processString, ' || ') ? explode(' || ', $processString) : [];
                 $replace_variable = '';
-                $filter = '';
 
                 /** Detect in-line condition, has alternative variables or singular variables */
                 if ($is_condition) {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -28,7 +28,6 @@ final class Parser
     public string $template_ext = 'tpl';
 
     /** Internal variables */
-    private string $export_string = '';
     private bool $is_comment_block = false;
     private string $block_content = '';
     private int $block_spaces = 0;
@@ -36,6 +35,12 @@ final class Parser
     private bool $is_js_script = false;
     private string $current_template = '';
     private int $current_line = 0;
+
+    /**
+     * Holds the parsed output string
+     * @var array<int, string>
+     */
+    private array $export_string = [];
 
     /**
      * shortcode_methods
@@ -110,7 +115,7 @@ final class Parser
     public function compile(string $templates, string $compile_filename, array $dataset): void
     {
         $this->parse($templates, $dataset, false);
-        file_put_contents($compile_filename, $this->export_string);
+        file_put_contents($compile_filename, implode('', $this->export_string));
     }
 
     /**
@@ -120,7 +125,7 @@ final class Parser
      */
     public function return(): string
     {
-        return $this->export_string;
+        return implode('', $this->export_string);
     }
 
     /**
@@ -129,7 +134,7 @@ final class Parser
      */
     public function clear(): Parser
     {
-        $this->export_string = '';
+        $this->export_string = [];
         return $this;
     }
 
@@ -489,7 +494,7 @@ final class Parser
 
         // Check if line should not be rendered
         if (!$render) {
-            $this->export_string .= $this_line;
+            $this->export_string[] = $this_line;
             return;
         }
 
@@ -666,7 +671,7 @@ final class Parser
 
                             $process_each_block->parseInputString($block_content, $this_row, false);
                             $return_string .= $process_each_block->return();
-                            $process_each_block->export_string = '';
+                            $process_each_block->export_string = [];
 
                             $iterator_count += 1;
                         }
@@ -692,7 +697,7 @@ final class Parser
 
                             $process_each_block->parseInputString($block_content, $row_data, false);
                             $return_string .= $process_each_block->return();
-                            $process_each_block->export_string = '';
+                            $process_each_block->export_string = [];
 
                             $iterator_count += 1;
                         }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -459,11 +459,13 @@ final class Parser
                 /** Process variables, in-line conditions and in-line iterators */
                 $this_line = $this->processVariables((string) $this_line, $dataset);
 
+                /** Check if WP do_shortcode function exists */
+                $is_wp_shortcode = function_exists('do_shortcode');
+
                 /** Is shortcode */
                 if (preg_match_all("/\[(.*?)\]/", $this_line, $matches, PREG_SET_ORDER)) {
                     foreach ($matches as $theShortcode) {
-                        /** @disregard */
-                        $this_line = function_exists('do_shortcode')
+                        $this_line = $is_wp_shortcode
                             ? str_replace(
                                 $theShortcode[0],
                                 do_shortcode($this->processVariables($theShortcode[0], $dataset)),

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -668,7 +668,7 @@ final class Parser
 
                             $process_each_block->parseInputString($block_content, $this_row, false);
                             $return_string .= $process_each_block->return();
-                            $process_each_block->export_string = [];
+                            $process_each_block->clear();
 
                             $iterator_count += 1;
                         }
@@ -694,7 +694,7 @@ final class Parser
 
                             $process_each_block->parseInputString($block_content, $row_data, false);
                             $return_string .= $process_each_block->return();
-                            $process_each_block->export_string = [];
+                            $process_each_block->clear();
 
                             $iterator_count += 1;
                         }

--- a/src/filters.php
+++ b/src/filters.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Brace;
+declare(strict_types=1);
 
-use Brace\Parser;
+namespace Brace;
 
 trait Filters
 {

--- a/tests/testdox.txt
+++ b/tests/testdox.txt
@@ -25,6 +25,7 @@ Filter (ConditionTests\Filter)
  [x] Filter inline condition
  [x] Filter value by array index value
  [x] Filter each block
+ [x] Filter with array data nested variables
 
 Include (ConditionTests\Include)
  [x] Include template
@@ -52,6 +53,7 @@ Shortcode (ConditionTests\Shortcode)
  [x] Shortcode arrow function year
  [x] Shortcode with data variables
  [x] Shortcode with array data variables
+ [x] Shortcode with array data nested variables
 
 Syntax (ConditionTests\Syntax)
  [x] Inline condition block syntax error

--- a/tests/unit/filters/data-nested-variables.tpl
+++ b/tests/unit/filters/data-nested-variables.tpl
@@ -1,0 +1,3 @@
+{{each names as name}}
+[name name="{{ name->first_name|uppercase }}"]
+{{end}}

--- a/tests/unit/filters/filterTest.php
+++ b/tests/unit/filters/filterTest.php
@@ -150,4 +150,32 @@ final class FilterTest extends TestCase
                 ->return(),
         );
     }
+
+    public function testFilterWithArrayDataNestedVariables(): void
+    {
+        $brace = new Brace\Parser();
+        $brace->template_path = __DIR__ . '/';
+
+        $brace->regShortcode('name', fn($attributes) => $attributes['name']);
+        $brace->registerFilter('uppercase', fn($content) => strtoupper($content));
+
+        $names = [
+            0 => ['first_name' => 'Alex'],
+            1 => ['first_name' => 'John'],
+            2 => ['first_name' => 'Andre'],
+        ];
+
+        $this->assertEquals(
+            "ALEX\nJOHN\nANDRE\n",
+            $brace
+                ->Parse(
+                    'data-nested-variables',
+                    [
+                        'names' => $names,
+                    ],
+                    false,
+                )
+                ->return(),
+        );
+    }
 }

--- a/tests/unit/shortcodes/data-nested-variables.tpl
+++ b/tests/unit/shortcodes/data-nested-variables.tpl
@@ -1,0 +1,3 @@
+{{each names as name}}
+[name name="{{ name->first_name }}"]
+{{end}}

--- a/tests/unit/shortcodes/data-variables.tpl
+++ b/tests/unit/shortcodes/data-variables.tpl
@@ -1,3 +1,3 @@
 {{each names as name}}
-[name name="{{name}}"]
+[name name="{{ name }}"]
 {{end}}

--- a/tests/unit/shortcodes/shortcodeTest.php
+++ b/tests/unit/shortcodes/shortcodeTest.php
@@ -152,4 +152,30 @@ final class ShortcodeTest extends TestCase
                 ->return(),
         );
     }
+
+    public function testShortcodeWithArrayDataNestedVariables(): void
+    {
+        $brace = new Brace\Parser();
+        $brace->template_path = __DIR__ . '/';
+
+        $brace->regShortcode('name', fn($attributes) => $attributes['name']);
+        $names = [
+            0 => ['first_name' => 'Alex'],
+            1 => ['first_name' => 'John'],
+            2 => ['first_name' => 'Andre'],
+        ];
+
+        $this->assertEquals(
+            "Alex\nJohn\nAndre\n",
+            $brace
+                ->Parse(
+                    'data-nested-variables',
+                    [
+                        'names' => $names,
+                    ],
+                    false,
+                )
+                ->return(),
+        );
+    }
 }


### PR DESCRIPTION
## Description

This PR contains performance improvements and refactoring across the core parser, along with two new test cases covering nested variable handling.

**`src/Parser.php`**
- Added `declare(strict_types=1)`
- Changed `$export_string` from `string` to `array<int, string>` to avoid repeated string concatenation; `implode()` is called on output
- Added `shouldProcessLine()` method to skip processing on empty lines and lines with no template syntax, reducing unnecessary regex evaluations
- Simplified loop block iteration — two separate `for` loops merged into one with a computed `$step` direction
- `processBlock()` now uses `rtrim($string, "\n")` instead of `explode`/`array_pop`/`implode`
- Loop parser instance now cleared via `clear()` and `unset()` after use for better memory management
- Extracted `$is_wp_shortcode` check outside the shortcode loop

**`src/DataProcessing.php`**
- Added `declare(strict_types=1)`
- Added `str_contains` guards before regex calls in `checkForCount()` and `checkForCallable()` to avoid unnecessary regex overhead

**`src/filters.php`**
- Added `declare(strict_types=1)`
- Removed unused `use Brace\Parser` import

**CI**
- Updated `ci.yml` to trigger on the `merge` branch instead of `development`

**Dependency updates** (`composer.lock`)
- phpstan `2.1.54` → `2.1.55`, phpunit `13.1.8` → `13.1.10`, rector `2.4.2` → `2.4.3`, and various `sebastian/*` packages bumped to latest patch/minor versions

## Motivation and Context

The primary motivation is performance: avoiding unnecessary regex calls on lines that contain no template syntax, and reducing repeated string concatenation by accumulating output in an array. The `shouldProcessLine()` guard is particularly beneficial for templates with large amounts of plain HTML. The strict types declarations improve type safety across the codebase.

## How Has This Been Tested?

Two new test cases were added and all existing tests continue to pass:

- **`testShortcodeWithArrayDataNestedVariables`** — verifies shortcodes correctly resolve nested array variables (e.g. `name->first_name`) within an `{{each}}` block
- **`testFilterWithArrayDataNestedVariables`** — verifies filters (e.g. `uppercase`) are correctly applied to nested array variables within shortcode attributes in an `{{each}}` block

The full test suite (`tests/testdox.txt`) was run and all tests pass.