### PR TITLE
fix: allow spaces inside variable tags in templates

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -781,7 +781,7 @@ final class Parser
      */
     private function processVariables(string $template_string, array $dataset): string
     {
-        if (preg_match_all('/({{)(.*?)(}})/i', $template_string, $variables, PREG_SET_ORDER)) {
+        if (preg_match_all('/({{)\s*(.*?)\s*(}})/i', $template_string, $variables, PREG_SET_ORDER)) {
             foreach ($variables as $this_data_variable) {
                 $replace_string = $this_data_variable[0];
                 $processString = $this_data_variable[2];

--- a/tests/unit/variables/variableTest.php
+++ b/tests/unit/variables/variableTest.php
@@ -252,7 +252,9 @@ final class variableTest extends TestCase
         $brace = new Brace\Parser();
         $this->assertEquals(
             "<script>console.log(\"Dave\");</script>\n",
-            $brace->parseInputString('<script>console.log("{{name}}");</script>', ['name' => 'Dave'], false)->return(),
+            $brace
+                ->parseInputString('<script>console.log("{{ name }}");</script>', ['name' => 'Dave'], false)
+                ->return(),
         );
     }
 }


### PR DESCRIPTION
## Description
Updates the `processVariables` regex in `Parser.php` to trim optional whitespace inside variable tags. The pattern changes from `/({{)(.*?)(}})/i` to `/({{)\s*(.*?)\s*(}})/i`, allowing template variables to be written as `{{ name }}` in addition to `{{name}}`.

The unit test for script tag variable parsing is also updated to use the spaced syntax (`{{ name }}`), verifying the new behaviour works correctly.

## Motivation and Context
Previously, template variables with spaces inside the curly braces (e.g. `{{ name }}`) would not be resolved, as the regex required the variable name to be flush against the delimiters. This change makes the template syntax more flexible and consistent with common conventions in other templating engines.

## How Has This Been Tested?
The existing unit test in `tests/unit/variables/variableTest.php` was updated to use the spaced variable syntax (`{{ name }}`). The test suite was run to confirm the change resolves variables correctly with spaces and does not break any existing behaviour.