### PR TITLE
Implemented new Callables trait

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,11 @@
 /tests export-ignore
 /.github export-ignore
 /.githooks export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.lando.yml export-ignore
+/phpstan.neon export-ignore
+/rector.php export-ignore
+/captainhook.json export-ignore
+
+* text=auto

--- a/.lando.yml
+++ b/.lando.yml
@@ -8,4 +8,3 @@ services:
         webroot: .
         xdebug: false
         composer: []
-        composer_version: "2.8.5"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-![PHPUnit](https://github.com/aoliverwd/brace/actions/workflows/ci.yml/badge.svg) [![Latest Stable Version](https://poser.pugx.org/alexoliverwd/brace/v)](//packagist.org/packages/alexoliverwd/brace) [![License](https://poser.pugx.org/alexoliverwd/brace/license)](//packagist.org/packages/alexoliverwd/brace)
+![PHPUnit](https://github.com/aoliverwd/brace/actions/workflows/ci.yml/badge.svg)
+[![Latest Stable Version](https://poser.pugx.org/alexoliverwd/brace/v)](https://packagist.org/packages/alexoliverwd/brace)
+[![License](https://poser.pugx.org/alexoliverwd/brace/license)](https://packagist.org/packages/alexoliverwd/brace)
 
 <img src="https://github.com/aoliverwd/brace/wiki/branding/brace.svg" alt="Brace Logo" width="100">
 

--- a/composer.lock
+++ b/composer.lock
@@ -75,16 +75,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.29.1",
+            "version": "v1.29.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "0770e9b7fafd50d4586881d456d6eb41c9247a80"
+                "reference": "da1d1111a6aa2e082d2a388b194afe1ba0a05d14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/0770e9b7fafd50d4586881d456d6eb41c9247a80",
-                "reference": "0770e9b7fafd50d4586881d456d6eb41c9247a80",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/da1d1111a6aa2e082d2a388b194afe1ba0a05d14",
+                "reference": "da1d1111a6aa2e082d2a388b194afe1ba0a05d14",
                 "shasum": ""
             },
             "require": {
@@ -95,14 +95,14 @@
                 "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.95.1",
-                "illuminate/view": "^12.56.0",
-                "larastan/larastan": "^3.9.6",
+                "friendsofphp/php-cs-fixer": "^3.95.8",
+                "illuminate/view": "^12.62.0",
+                "larastan/larastan": "^3.10.0",
                 "laravel-zero/framework": "^12.1.0",
+                "laravel/agent-detector": "^2.0.2",
                 "mockery/mockery": "^1.6.12",
                 "nunomaduro/termwind": "^2.4.0",
-                "pestphp/pest": "^3.8.6",
-                "shipfastlabs/agent-detector": "^1.1.3"
+                "pestphp/pest": "^3.8.6"
             },
             "bin": [
                 "builds/pint"
@@ -139,7 +139,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2026-04-20T15:26:14+00:00"
+            "time": "2026-06-16T15:34:04+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1040,16 +1040,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "13.2.0",
+            "version": "13.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3796ea973f1e7698f0d432c1c66662af9764fd9a"
+                "reference": "60da0ff1e10a0f72ee18a24117ec3b613a346bba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3796ea973f1e7698f0d432c1c66662af9764fd9a",
-                "reference": "3796ea973f1e7698f0d432c1c66662af9764fd9a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/60da0ff1e10a0f72ee18a24117ec3b613a346bba",
+                "reference": "60da0ff1e10a0f72ee18a24117ec3b613a346bba",
                 "shasum": ""
             },
             "require": {
@@ -1063,7 +1063,7 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.4.1",
-                "phpunit/php-code-coverage": "^14.2",
+                "phpunit/php-code-coverage": "^14.2.2",
                 "phpunit/php-file-iterator": "^7.0.0",
                 "phpunit/php-invoker": "^7.0.0",
                 "phpunit/php-text-template": "^6.0.0",
@@ -1120,7 +1120,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.2.0"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.2.1"
             },
             "funding": [
                 {
@@ -1128,25 +1128,25 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-06-05T03:13:07+00:00"
+            "time": "2026-06-15T13:14:22+00:00"
         },
         {
             "name": "rector/rector",
-            "version": "2.4.5",
+            "version": "2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+                "reference": "49ff6339174bdbdf50b0b35ecbcff14a05ac9e24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
-                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/49ff6339174bdbdf50b0b35ecbcff14a05ac9e24",
+                "reference": "49ff6339174bdbdf50b0b35ecbcff14a05ac9e24",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.56"
+                "phpstan/phpstan": "^2.2.2"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -1180,7 +1180,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.5.2"
             },
             "funding": [
                 {
@@ -1188,7 +1188,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T21:03:22+00:00"
+            "time": "2026-06-22T11:39:33+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -593,11 +593,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.55",
+            "version": "2.2.2",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9eaac3826ed5e9b8427350a43cac825eeca3f566",
-                "reference": "9eaac3826ed5e9b8427350a43cac825eeca3f566",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
+                "reference": "e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
                 "shasum": ""
             },
             "require": {
@@ -619,6 +619,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -642,20 +653,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-18T11:57:34+00:00"
+            "time": "2026-06-05T09:00:01+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "14.1.9",
+            "version": "14.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "655533a65696bbc4231cd8027af150dadc40ec88"
+                "reference": "10d7da3628a99289cdf4c662dd7f0d73f1baec83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/655533a65696bbc4231cd8027af150dadc40ec88",
-                "reference": "655533a65696bbc4231cd8027af150dadc40ec88",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/10d7da3628a99289cdf4c662dd7f0d73f1baec83",
+                "reference": "10d7da3628a99289cdf4c662dd7f0d73f1baec83",
                 "shasum": ""
             },
             "require": {
@@ -667,14 +678,14 @@
                 "php": ">=8.4",
                 "phpunit/php-text-template": "^6.0",
                 "sebastian/complexity": "^6.0",
-                "sebastian/environment": "^9.2",
+                "sebastian/environment": "^9.3.2",
                 "sebastian/git-state": "^1.0",
-                "sebastian/lines-of-code": "^5.0",
+                "sebastian/lines-of-code": "^5.0.1",
                 "sebastian/version": "^7.0",
                 "theseer/tokenizer": "^2.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.1"
+                "phpunit/phpunit": "^13.2.0"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -683,7 +694,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "14.1.x-dev"
+                    "dev-main": "14.2.x-dev"
                 }
             },
             "autoload": {
@@ -712,7 +723,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.1.9"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.2.2"
             },
             "funding": [
                 {
@@ -732,7 +743,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-16T05:16:14+00:00"
+            "time": "2026-06-08T11:50:38+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1029,16 +1040,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "13.1.10",
+            "version": "13.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "38959098d3c10660a189afaa35a94290c1de67bb"
+                "reference": "3796ea973f1e7698f0d432c1c66662af9764fd9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/38959098d3c10660a189afaa35a94290c1de67bb",
-                "reference": "38959098d3c10660a189afaa35a94290c1de67bb",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3796ea973f1e7698f0d432c1c66662af9764fd9a",
+                "reference": "3796ea973f1e7698f0d432c1c66662af9764fd9a",
                 "shasum": ""
             },
             "require": {
@@ -1052,21 +1063,22 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.4.1",
-                "phpunit/php-code-coverage": "^14.1.8",
+                "phpunit/php-code-coverage": "^14.2",
                 "phpunit/php-file-iterator": "^7.0.0",
                 "phpunit/php-invoker": "^7.0.0",
                 "phpunit/php-text-template": "^6.0.0",
                 "phpunit/php-timer": "^9.0.0",
                 "sebastian/cli-parser": "^5.0.0",
-                "sebastian/comparator": "^8.1.3",
-                "sebastian/diff": "^8.3.0",
-                "sebastian/environment": "^9.3.0",
-                "sebastian/exporter": "^8.0.2",
+                "sebastian/comparator": "^8.3.0",
+                "sebastian/diff": "^9.0",
+                "sebastian/environment": "^9.3.2",
+                "sebastian/exporter": "^8.1.0",
+                "sebastian/file-filter": "^1.0",
                 "sebastian/git-state": "^1.0",
-                "sebastian/global-state": "^9.0.0",
+                "sebastian/global-state": "^9.0.1",
                 "sebastian/object-enumerator": "^8.0.0",
                 "sebastian/recursion-context": "^8.0.0",
-                "sebastian/type": "^7.0.0",
+                "sebastian/type": "^7.0.1",
                 "sebastian/version": "^7.0.0",
                 "staabm/side-effects-detector": "^1.0.5"
             },
@@ -1076,7 +1088,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "13.1-dev"
+                    "dev-main": "13.2-dev"
                 }
             },
             "autoload": {
@@ -1108,7 +1120,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.10"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.2.0"
             },
             "funding": [
                 {
@@ -1116,25 +1128,25 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-05-15T08:03:56+00:00"
+            "time": "2026-06-05T03:13:07+00:00"
         },
         {
             "name": "rector/rector",
-            "version": "2.4.3",
+            "version": "2.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "891824c6c59f02a56a5dd58ea8edc44e6c0ece29"
+                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/891824c6c59f02a56a5dd58ea8edc44e6c0ece29",
-                "reference": "891824c6c59f02a56a5dd58ea8edc44e6c0ece29",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.48"
+                "phpstan/phpstan": "^2.1.56"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -1168,7 +1180,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.3"
+                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
             },
             "funding": [
                 {
@@ -1176,7 +1188,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-12T11:17:24+00:00"
+            "time": "2026-05-26T21:03:22+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1249,27 +1261,27 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "8.2.0",
+            "version": "8.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "ddacb462216a4f6d97e84bf08165b9074ddbafeb"
+                "reference": "c025fc7604afab3f195fab7cdaf72327331af241"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ddacb462216a4f6d97e84bf08165b9074ddbafeb",
-                "reference": "ddacb462216a4f6d97e84bf08165b9074ddbafeb",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c025fc7604afab3f195fab7cdaf72327331af241",
+                "reference": "c025fc7604afab3f195fab7cdaf72327331af241",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
                 "php": ">=8.4",
-                "sebastian/diff": "^8.3",
-                "sebastian/exporter": "^8.0.3"
+                "sebastian/diff": "^9.0",
+                "sebastian/exporter": "^8.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.1.10"
+                "phpunit/phpunit": "^13.2"
             },
             "suggest": {
                 "ext-bcmath": "For comparing BcMath\\Number objects"
@@ -1277,7 +1289,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.2-dev"
+                    "dev-main": "8.3-dev"
                 }
             },
             "autoload": {
@@ -1317,7 +1329,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/8.2.0"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/8.3.0"
             },
             "funding": [
                 {
@@ -1337,7 +1349,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T11:55:37+00:00"
+            "time": "2026-06-05T03:06:45+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -1411,29 +1423,29 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "8.3.0",
+            "version": "9.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "b36d33b6e796513de7cb7df053afb3f55eefcd47"
+                "reference": "a3fb6a298a265ff487a91bbea46e03cd01dbb226"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b36d33b6e796513de7cb7df053afb3f55eefcd47",
-                "reference": "b36d33b6e796513de7cb7df053afb3f55eefcd47",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/a3fb6a298a265ff487a91bbea46e03cd01dbb226",
+                "reference": "a3fb6a298a265ff487a91bbea46e03cd01dbb226",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.0",
-                "symfony/process": "^7.2"
+                "phpunit/phpunit": "^13.2",
+                "symfony/process": "^7.4.13"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.3-dev"
+                    "dev-main": "9.0-dev"
                 }
             },
             "autoload": {
@@ -1466,7 +1478,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/8.3.0"
+                "source": "https://github.com/sebastianbergmann/diff/tree/9.0.0"
             },
             "funding": [
                 {
@@ -1486,27 +1498,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-15T04:58:09+00:00"
+            "time": "2026-06-05T03:04:51+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "9.3.0",
+            "version": "9.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6767059a30e4277ac95ee034809e793528464768"
+                "reference": "6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6767059a30e4277ac95ee034809e793528464768",
-                "reference": "6767059a30e4277ac95ee034809e793528464768",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e",
+                "reference": "6c9e487c9eb706a8d258102a1c0b0a3e53e86c2e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.0"
+                "phpunit/phpunit": "^13.1.11"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -1542,7 +1554,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/9.3.0"
+                "source": "https://github.com/sebastianbergmann/environment/tree/9.3.2"
             },
             "funding": [
                 {
@@ -1562,20 +1574,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-15T12:14:03+00:00"
+            "time": "2026-05-25T13:41:38+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "8.0.3",
+            "version": "8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "9b54f1afabb977a097ef353600d41a372ccde617"
+                "reference": "c0d29a945f8cf82f300a05e69874508e307ca4c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/9b54f1afabb977a097ef353600d41a372ccde617",
-                "reference": "9b54f1afabb977a097ef353600d41a372ccde617",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/c0d29a945f8cf82f300a05e69874508e307ca4c6",
+                "reference": "c0d29a945f8cf82f300a05e69874508e307ca4c6",
                 "shasum": ""
             },
             "require": {
@@ -1589,7 +1601,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.0-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -1632,7 +1644,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/8.0.3"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/8.1.0"
             },
             "funding": [
                 {
@@ -1652,7 +1664,76 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T04:38:47+00:00"
+            "time": "2026-05-21T11:50:56+00:00"
+        },
+        {
+            "name": "sebastian/file-filter",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/file-filter.git",
+                "reference": "33a26f394330f6faa7684bb9cc73afb7727aae93"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/file-filter/zipball/33a26f394330f6faa7684bb9cc73afb7727aae93",
+                "reference": "33a26f394330f6faa7684bb9cc73afb7727aae93",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for filtering files",
+            "homepage": "https://github.com/sebastianbergmann/file-filter",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/file-filter/issues",
+                "security": "https://github.com/sebastianbergmann/file-filter/security/policy",
+                "source": "https://github.com/sebastianbergmann/file-filter/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/file-filter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-22T07:20:04+00:00"
         },
         {
             "name": "sebastian/git-state",
@@ -1725,16 +1806,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "9.0.0",
+            "version": "9.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e52e3dc22441e6218c710afe72c3042f8fc41ea7"
+                "reference": "ba68ba79da690cf7eddefd3ce5b78b20b9ba9945"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e52e3dc22441e6218c710afe72c3042f8fc41ea7",
-                "reference": "e52e3dc22441e6218c710afe72c3042f8fc41ea7",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ba68ba79da690cf7eddefd3ce5b78b20b9ba9945",
+                "reference": "ba68ba79da690cf7eddefd3ce5b78b20b9ba9945",
                 "shasum": ""
             },
             "require": {
@@ -1744,7 +1825,7 @@
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^13.0"
+                "phpunit/phpunit": "^13.1.13"
             },
             "type": "library",
             "extra": {
@@ -1775,7 +1856,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/9.0.0"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/9.0.1"
             },
             "funding": [
                 {
@@ -1795,7 +1876,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-06T04:45:13+00:00"
+            "time": "2026-06-01T15:11:33+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -2328,5 +2409,5 @@
         "php": ">=8.4.1"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Callables.php
+++ b/src/Callables.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brace;
+
+trait Callables
+{
+    /**
+     * callable_methods
+     * @var array<string, callable>
+     */
+    private array $callable_methods = [];
+
+    /**
+     * Register a callable method
+     *
+     * @param string $name
+     * @param callable $method
+     * @return Parser
+     */
+    public function registerCallable(string $name, callable $method): Parser
+    {
+        if (!isset($this->callable_methods[$name])) {
+            $this->callable_methods[$name] = $method;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Call a callable method
+     *
+     * @param string $method
+     * @param string $content
+     * @return string
+     */
+    private function callables(string $method, string $content): string
+    {
+        if (isset($this->callable_methods[$method])) {
+            return $this->callable_methods[$method](preg_replace(['/^"(.*?)"$/', "/^'(.*?)'$/"], '$1', $content));
+        }
+
+        return '';
+    }
+
+    /**
+     * Check if the line contains callable methods
+     *
+     * @param string $line
+     * @return array<int, array<int, string>>|false
+     */
+    private function hasCallables(string $line): array|false
+    {
+        if (preg_match_all('/([a-zA-Z0-9_-]+)\((.*?)\)/', $line, $matches, PREG_SET_ORDER)) {
+            return $matches;
+        }
+
+        return false;
+    }
+
+    /**
+     * Process callable methods in the content
+     *
+     * @param string $content
+     * @return string
+     */
+    private function processCallables(string $content): string
+    {
+        $callables = $this->hasCallables($content);
+
+        if (!$callables) {
+            return $content;
+        }
+
+        foreach ($callables as $callableMethod) {
+            if (isset($this->callable_methods[$callableMethod[1]])) {
+                $content = str_replace(
+                    $callableMethod[0],
+                    $this->callables(method: $callableMethod[1], content: $callableMethod[2]),
+                    $content,
+                );
+            }
+        }
+
+        return $content;
+    }
+}

--- a/src/Callables.php
+++ b/src/Callables.php
@@ -13,6 +13,11 @@ trait Callables
     private array $callable_methods = [];
 
     /**
+     * The pattern used to match callable methods in the content
+     */
+    private string $callable_pattern = '/([a-zA-Z0-9_-]+)\((.*?)\)/';
+
+    /**
      * Register a callable method
      *
      * @param string $name
@@ -45,6 +50,17 @@ trait Callables
     }
 
     /**
+     * Match a callable method in the line
+     *
+     * @param string $line
+     * @return bool
+     */
+    private function matchCallable(string $line): bool
+    {
+        return (bool) preg_match($this->callable_pattern, $line);
+    }
+
+    /**
      * Check if the line contains callable methods
      *
      * @param string $line
@@ -52,7 +68,7 @@ trait Callables
      */
     private function hasCallables(string $line): array|false
     {
-        if (preg_match_all('/([a-zA-Z0-9_-]+)\((.*?)\)/', $line, $matches, PREG_SET_ORDER)) {
+        if (preg_match_all($this->callable_pattern, $line, $matches, PREG_SET_ORDER)) {
             return $matches;
         }
 

--- a/src/DataProcessing.php
+++ b/src/DataProcessing.php
@@ -6,8 +6,11 @@ namespace Brace;
 
 trait DataProcessing
 {
-    /** Use Filters trait */
+    // Use Filters trait
     use Filters;
+
+    // Use Callables trait
+    use Callables;
 
     /**
      * Process data chain
@@ -23,7 +26,6 @@ trait DataProcessing
 
         // Check for search by array value
         $array_value_seratch = explode('->?', (string) $filter[0]);
-
         if (count($array_value_seratch) > 1) {
             foreach ($array_value_seratch as $thisVar) {
                 if (preg_match('/^(.*?)\[(.*?)\](.*)$/', $thisVar, $matches) && is_array($dataset)) {
@@ -44,6 +46,7 @@ trait DataProcessing
             }
         }
 
+        // Process chain
         return self::processChain(
             (string) $filter[0],
             is_array($dataset) ? $dataset : [],
@@ -69,6 +72,11 @@ trait DataProcessing
         // Check for count
         $is_count = self::checkForCount($input);
         $input = !empty($is_count) ? $is_count : $input;
+
+        // Process callables
+        if ($this->matchCallable($input)) {
+            return $this->processFilter($filter, $this->processCallables($input));
+        }
 
         // Process nested variables
         $return = [];

--- a/src/DataProcessing.php
+++ b/src/DataProcessing.php
@@ -60,17 +60,18 @@ trait DataProcessing
      */
     private function processChain(string $input, array $dataset, string $filter): mixed
     {
-        $return = [];
-
-        $is_count = self::checkForCount($input);
+        // Check for boolean callable
         $is_a_callable = self::checkForCallable($input);
-
         if (!empty($is_a_callable) && is_callable($is_a_callable['callable'])) {
             return boolval(call_user_func($is_a_callable['callable'], $is_a_callable['attributes']));
         }
 
+        // Check for count
+        $is_count = self::checkForCount($input);
         $input = !empty($is_count) ? $is_count : $input;
 
+        // Process nested variables
+        $return = [];
         foreach (explode('->', $input) as $thisVar) {
             if (is_array($dataset) && isset($dataset[$thisVar])) {
                 $dataset = $dataset[$thisVar];

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -36,7 +36,7 @@ final class Parser
     private int $block_spaces = 0;
     private bool $is_block = false;
     private bool $is_js_script = false;
-    private string $current_template = '';
+    private string $current_template = 'inline';
     private int $current_line = 0;
 
     /**
@@ -436,8 +436,12 @@ final class Parser
                 }
             }
 
-            /** Is Callable */
-            $this_line = $this->processCallables($this_line);
+            // Callables without {{ }} will be removed in future versions
+            if ($this->matchCallable($this_line)) {
+                $error_message = sprintf('Callables without {{ }} will be removed in a future release. Use {{ function_name() }} instead. File: %s, Line: %d', $this->current_template, $this->current_line);
+                trigger_error($error_message, E_USER_DEPRECATED);
+                $this_line = $this->processCallables($this_line);
+            }
         }
 
         // Check if line should not be rendered

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -288,11 +288,6 @@ final class Parser
             $this_line = $this->processVariables((string) $this_line, $dataset);
         }
 
-        // Check for end of inline JS script tag
-        if ($this->is_js_script && preg_match("/<\/script>/", $this_line)) {
-            $this->is_js_script = false;
-        }
-
         // Check if line should be processed
         if (!$this->is_js_script && $this->shouldProcessLine($this_line)) {
             /** Remove comment blocks */
@@ -442,6 +437,11 @@ final class Parser
                 trigger_error($error_message, E_USER_DEPRECATED);
                 $this_line = $this->processCallables($this_line);
             }
+        }
+
+        // Check for end of inline JS script tag
+        if ($this->is_js_script && preg_match("/<\/script>/", $this_line)) {
+            $this->is_js_script = false;
         }
 
         // Check if line should not be rendered

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -22,6 +22,9 @@ final class Parser
     /** Use DataProcessing trait */
     use DataProcessing;
 
+    /** Use Callables trait */
+    use Callables;
+
     /** Public variables */
     public bool $remove_comment_blocks = true;
     public string $template_path = __DIR__ . '/';
@@ -47,12 +50,6 @@ final class Parser
      * @var array<string, string|callable>
      */
     private array $shortcode_methods = [];
-
-    /**
-     * callable_methods
-     * @var array<string, callable>
-     */
-    private array $callable_methods = [];
 
     /**
      * block_condition
@@ -206,38 +203,6 @@ final class Parser
 
         /** Return shortcode syntax if method is not callable */
         return $shortcodeSyntax;
-    }
-
-    /**
-     * Register a callable method
-     *
-     * @param string $name
-     * @param callable $method
-     * @return Parser
-     */
-    public function registerCallable(string $name, callable $method): Parser
-    {
-        if (!isset($this->callable_methods[$name])) {
-            $this->callable_methods[$name] = $method;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Call a callable method
-     *
-     * @param string $method
-     * @param string $content
-     * @return string
-     */
-    private function callables(string $method, string $content): string
-    {
-        if (isset($this->callable_methods[$method])) {
-            return $this->callable_methods[$method](preg_replace(['/^"(.*?)"$/', "/^'(.*?)'$/"], '$1', $content));
-        }
-
-        return '';
     }
 
     /**
@@ -472,17 +437,7 @@ final class Parser
             }
 
             /** Is Callable */
-            if (preg_match_all("/([a-zA-Z0-9_-]+)\((.*?)\)/", $this_line, $matches, PREG_SET_ORDER)) {
-                foreach ($matches as $callableMethod) {
-                    if (isset($this->callable_methods[$callableMethod[1]])) {
-                        $this_line = str_replace(
-                            $callableMethod[0],
-                            $this->callables(method: $callableMethod[1], content: $callableMethod[2]),
-                            $this_line,
-                        );
-                    }
-                }
-            }
+            $this_line = $this->processCallables($this_line);
         }
 
         // Check if line should not be rendered

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -746,11 +746,11 @@ final class Parser
                 $has_alternative_vars = str_contains($processString, ' || ') ? explode(' || ', $processString) : [];
                 $replace_variable = '';
 
-                /** Detect in-line condition, has alternative variables or singular variables */
+                // Detect in-line condition, has alternative variables or singular variables
                 if ($is_condition) {
                     $replace_variable = $this->processInlineCondition($processString, $dataset);
                 } elseif ($is_itterator) {
-                    /** Processes in-line iterator */
+                    // Processes in-line iterator
                     $replace_variable = $this->processInlineIterator($processString, $dataset);
                 } elseif (count($has_alternative_vars) > 1) {
                     foreach ($has_alternative_vars as $this_variable) {

--- a/tests/testdox.txt
+++ b/tests/testdox.txt
@@ -4,6 +4,7 @@ Callable (ConditionTests\Callable)
  [x] Callable method with arg single quotes
  [x] Callable method with arg no quotes
  [x] Callable method with parenthesis
+ [x] Callable method with braces
 
 Conditions (ConditionTests\Conditions)
  [x] Equals

--- a/tests/testdox.txt
+++ b/tests/testdox.txt
@@ -5,6 +5,10 @@ Callable (ConditionTests\Callable)
  [x] Callable method with arg no quotes
  [x] Callable method with parenthesis
  [x] Callable method with braces
+ [x] Callable method with arg double quotes with braces
+ [x] Callable method with arg single quotes with braces
+ [x] Callable method with arg no quotes with braces
+ [x] Callable method with parenthesis with braces
 
 Conditions (ConditionTests\Conditions)
  [x] Equals

--- a/tests/unit/callables/callableTest.php
+++ b/tests/unit/callables/callableTest.php
@@ -87,6 +87,7 @@ final class CallableTest extends TestCase
         );
     }
 
+
     /**
      * callable method
      * @return void
@@ -102,4 +103,57 @@ final class CallableTest extends TestCase
             $brace->parseInputString('{{ foo() }}', [], false)->return()
         );
     }
+
+    /**
+     * callable method with argument
+     * @return void
+     */
+    public function testCallableMethodWithArgDoubleQuotesWithBraces(): void
+    {
+        $brace = new Brace\Parser();
+
+        $brace->registerCallable('foo', fn($content) => $content);
+
+        $this->assertEquals(
+            "bar\n",
+            $brace->parseInputString('{{ foo("bar") }}', [], false)->return()
+        );
+    }
+
+    public function testCallableMethodWithArgSingleQuotesWithBraces(): void
+    {
+        $brace = new Brace\Parser();
+
+        $brace->registerCallable('foo', fn($content) => $content);
+
+        $this->assertEquals(
+            "bar\n",
+            $brace->parseInputString("{{ foo('bar') }}", [], false)->return()
+        );
+    }
+
+    public function testCallableMethodWithArgNoQuotesWithBraces(): void
+    {
+        $brace = new Brace\Parser();
+
+        $brace->registerCallable('foo', fn($content) => $content);
+
+        $this->assertEquals(
+            "bar\n",
+            $brace->parseInputString('{{ foo(bar) }}', [], false)->return()
+        );
+    }
+
+    public function testCallableMethodWithParenthesisWithBraces(): void
+    {
+        $brace = new Brace\Parser();
+
+        $brace->registerCallable('foo', fn($content) => $content);
+
+        $this->assertEquals(
+            "bar(foo)\n",
+            $brace->parseInputString('{{ foo(bar(foo)) }}', [], false)->return()
+        );
+    }
+
 }

--- a/tests/unit/callables/callableTest.php
+++ b/tests/unit/callables/callableTest.php
@@ -86,4 +86,20 @@ final class CallableTest extends TestCase
             $brace->parseInputString('foo(bar(foo))', [], false)->return()
         );
     }
+
+    /**
+     * callable method
+     * @return void
+     */
+    public function testCallableMethodWithBraces(): void
+    {
+        $brace = new Brace\Parser();
+
+        $brace->registerCallable('foo', fn() => 'bar');
+
+        $this->assertEquals(
+            "bar\n",
+            $brace->parseInputString('{{ foo() }}', [], false)->return()
+        );
+    }
 }


### PR DESCRIPTION
## Description

- **New `Callables` trait** (`src/Callables.php`): Extracted callable method logic from `Parser` into a dedicated reusable trait, including `registerCallable()`, `callables()`, `matchCallable()`, `hasCallables()`, and `processCallables()` methods.
- **Callable syntax now supports `{{ }}` braces**: Callables can now be invoked using the standard template variable syntax (e.g., `{{ foo("bar") }}`), in addition to the previous bare syntax.
- **Deprecation notice**: Callables used without `{{ }}` braces now trigger an `E_USER_DEPRECATED` warning, with the filename and line number included in the message.
- **`DataProcessing` trait updated**: Integrated the `Callables` trait and wired callable processing into the data chain.
- **JS script tag handling fix**: Moved the end-of-inline-JS-script detection to after line processing (rather than before), correcting the processing order.
- **`Parser.php` cleanup**: Removed now-redundant `callable_methods` property and callable methods; set `current_template` default to `'inline'`.
- **Dependency updates**: `composer.lock` updated with latest versions of `phpunit`, `phpstan`, `rector`, `sebastian/*` packages, and Composer plugin API bumped to `2.9.0`.
- **`.gitattributes`**: Added `export-ignore` entries for config files and `* text=auto` for line-ending normalisation.
- **`README.md`**: Fixed badge/link URLs from `//` to `https://`.

## Motivation and Context

The callable syntax was previously only supported without `{{ }}` delimiters, making it inconsistent with the rest of the template engine. This change introduces support for the standard brace syntax while deprecating the old bare syntax to allow a clean migration path for users before it is removed in a future release. The refactor into a dedicated `Callables` trait also improves code organisation and reusability.

## How Has This Been Tested?

Five new PHPUnit test cases were added to `tests/unit/callables/callableTest.php` covering:
- `{{ foo() }}` — callable with no arguments
- `{{ foo("bar") }}` — callable with double-quoted argument
- `{{ foo('bar') }}` — callable with single-quoted argument
- `{{ foo(bar) }}` — callable with unquoted argument
- `{{ foo(bar(foo)) }}` — callable with nested parentheses

All new and existing tests pass, as confirmed by the updated `tests/testdox.txt`.